### PR TITLE
1.3 support

### DIFF
--- a/ConsoleReporter.coffee
+++ b/ConsoleReporter.coffee
@@ -113,5 +113,5 @@ class ConsoleReporter extends  practical.mocha.BaseReporter
     finally
       log.return()
 
-Meteor.startup ->
+module.exports.runTests = () ->
   MochaRunner.setReporter(ConsoleReporter)

--- a/package.js
+++ b/package.js
@@ -5,14 +5,15 @@ Package.describe({
   git: 'https://github.com/practicalmeteor/meteor-mocha-console-reporter.git',
   // By default, Meteor will default to using README.md for documentation.
   // To avoid submitting documentation, set this field to null.
-  documentation: 'README.md'
+  documentation: 'README.md',
+  testOnly: true
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('1.1.0.3');
-  api.use(['coffeescript', "practicalmeteor:mocha@2.1.0_4"]);
-  api.imply("practicalmeteor:mocha@2.1.0_4");
-  api.addFiles('ConsoleReporter.coffee', 'client');
+  api.use(['coffeescript', "avital:mocha", 'practicalmeteor:loglevel', 'ecmascript']);
+  api.imply("avital:mocha");
+  api.mainModule('ConsoleReporter.coffee', 'client');
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
This one is super simple! 

Note that I've got dependencies on `avital:mocha` in there. That should be `practicalmeteor:mocha` once you've released that package.
