### PR TITLE
Use the last version of practicalmeteor:mocha

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'practicalmeteor:mocha-console-runner',
-  version: '0.2.3',
+  version: '0.2.4',
   summary: 'A mocha console reporter for running your package tests from the command line with spacejam.',
   git: 'https://github.com/practicalmeteor/meteor-mocha-console-runner.git',
   // By default, Meteor will default to using README.md for documentation.
@@ -11,9 +11,9 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom("1.3");
-  api.use(['coffeescript', "practicalmeteor:mocha@=2.4.5_5", 'practicalmeteor:loglevel@1.2.0_2', 'ecmascript']);
+  api.use(['coffeescript', "practicalmeteor:mocha@=2.4.5_6", 'practicalmeteor:loglevel@1.2.0_2', 'ecmascript']);
   api.mainModule('ConsoleReporter.coffee', 'client');
-  api.imply("practicalmeteor:mocha@=2.4.5_5");
+  api.imply("practicalmeteor:mocha@=2.4.5_6");
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
## Current behavior

`meteor add practicalmeteor:mocha practicalmeteor:mocha-console-runner`
will install the last version of `mocha-console-runner`, which means `practicalmeteor:mocha@2.4.5_5`
## Quick fix

`meteor add practicalmeteor:mocha@2.4.5_6 practicalmeteor:mocha-console-runner`
## Todo
- [ ] Update `test-app`
- [ ] Update `test-package`
- [ ] Update `.versions`
- [ ] Publish
